### PR TITLE
remove: `preset: []`

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ const colors = require('tailwindcss/colors')
 module.exports = {
   // mode: 'jit',
   purge: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
-  presets: [],
+  // presets: [],
   darkMode: false, // or 'media' or 'class'
   theme: {
     screens: {


### PR DESCRIPTION
Becuase of jit mode can generating class that unset in tailwind.config.js , 
so everyone **never notice** this problem.

If you generate `tailwind.config.js` file using tailwindcss or tailwindcss-cli and set a flag `-f` to get full version of config , 
you'll have a line of `preset: []` .

### What's the problem ?
The config option `preset` this tell tailwind's preset loader to get preset files in array.
for example, here is a preset called `myPreset.js`

```javascript
// myPreset.js
module.exports = {
  theme: {
    colors: {
      blue: {
        light: '#85d7ff',
        DEFAULT: '#1fb6ff',
        dark: '#009eeb',
      },
      // ...
      },
      zIndex: {
        60: '60',
        70: '70',
        80: '80',
        90: '90',
        100: '100',
      },
    }
  },
  plugins: [require('@tailwindcss/aspect-ratio')],
}
```
and this is `tailwind.config.js` :
```javascript
// tailwind.config.js
module.exports = {
  presets: [
    require('./myPreset.js')
  ],
 theme: {
    colors: {
      'just-blue': "#0000FF",
    }
    extend: {
      colors: {
        'green-blue': "#00FFFF",
      }
    }
  }
}
```
And if runing , you'll know `just-blue` is inactive, but `green-blue` passed, why ?
because , now your `tailwind.config.js` is based on your preset file `myPreset.js` ,
so in your `tailwind.config.js` file, tailwind just can only read the **`extands`** configs.
(just for sample, it's not actual situation.)

### Summary
Look at your original `tailwind.config.js`, the value of option `preset` is `[]` ,
tailwind will **not load any preset and just read the additional configs like `extands`**
just remove it, and it will working well.

Learn more about [Presets](https://tailwindcss.tw/docs/presets)